### PR TITLE
Fix HTTPS config for empty/no Caddyfile

### DIFF
--- a/caddy/https/https_test.go
+++ b/caddy/https/https_test.go
@@ -46,7 +46,7 @@ func TestConfigQualifies(t *testing.T) {
 		cfg    server.Config
 		expect bool
 	}{
-		{server.Config{Host: ""}, true},
+		{server.Config{Host: ""}, false},
 		{server.Config{Host: "localhost"}, false},
 		{server.Config{Host: "123.44.3.21"}, false},
 		{server.Config{Host: "example.com"}, true},
@@ -302,6 +302,7 @@ func TestGroupConfigsByEmail(t *testing.T) {
 func TestMarkQualified(t *testing.T) {
 	// TODO: TestConfigQualifies and this test share the same config list...
 	configs := []server.Config{
+		{Host: ""},
 		{Host: "localhost"},
 		{Host: "123.44.3.21"},
 		{Host: "example.com"},
@@ -313,9 +314,8 @@ func TestMarkQualified(t *testing.T) {
 		{Host: "example.com", Port: "1234"},
 		{Host: "example.com", Scheme: "https"},
 		{Host: "example.com", Port: "80", Scheme: "https"},
-		{Host: ""},
 	}
-	expectedManagedCount := 5
+	expectedManagedCount := 4
 
 	MarkQualified(configs)
 

--- a/server/config.go
+++ b/server/config.go
@@ -65,10 +65,11 @@ func (c Config) Address() string {
 
 // TLSConfig describes how TLS should be configured and used.
 type TLSConfig struct {
-	Enabled                  bool
+	Enabled                  bool // will be set to true if TLS is enabled
 	LetsEncryptEmail         string
-	Managed                  bool // will be set to true if config qualifies for automatic, managed TLS
-	Manual                   bool // will be set to true if user provides the cert and key files
+	Manual                   bool // will be set to true if user provides own certs and keys
+	Managed                  bool // will be set to true if config qualifies for automatic/managed HTTPS
+	OnDemand                 bool // will be set to true if user enables on-demand TLS (obtain certs during handshakes)
 	Ciphers                  []uint16
 	ProtocolMinVersion       uint16
 	ProtocolMaxVersion       uint16

--- a/server/server.go
+++ b/server/server.go
@@ -63,12 +63,14 @@ func New(addr string, configs []Config, gracefulTimeout time.Duration) (*Server,
 	var useTLS, useOnDemandTLS bool
 	if len(configs) > 0 {
 		useTLS = configs[0].TLS.Enabled
-		host, _, err := net.SplitHostPort(addr)
-		if err != nil {
-			host = addr
-		}
-		if useTLS && host == "" && !configs[0].TLS.Manual {
-			useOnDemandTLS = true
+		if useTLS {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				host = addr
+			}
+			if host == "" && configs[0].TLS.OnDemand {
+				useOnDemandTLS = true
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes a regression introduced in recent commits that enabled TLS on the default ":2015" config. This fix is possible because On-Demand TLS is no longer implicit; it must be explicitly enabled by the user by setting a maximum number of certificates to issue.