### PR TITLE
Bug fixes and other improvements to TLS functions

### DIFF
--- a/caddy/https/setup.go
+++ b/caddy/https/setup.go
@@ -20,12 +20,12 @@ import (
 // are specified by the user in the config file. All the automatic HTTPS
 // stuff comes later outside of this function.
 func Setup(c *setup.Controller) (middleware.Middleware, error) {
-	if c.Scheme == "http" {
+	if c.Port == "80" || c.Scheme == "http" {
 		c.TLS.Enabled = false
 		log.Printf("[WARNING] TLS disabled for %s://%s.", c.Scheme, c.Address())
-	} else {
-		c.TLS.Enabled = true
+		return nil, nil
 	}
+	c.TLS.Enabled = true
 
 	for c.Next() {
 		var certificateFile, keyFile, loadDir, maxCerts string
@@ -38,6 +38,7 @@ func Setup(c *setup.Controller) (middleware.Middleware, error) {
 			// user can force-disable managed TLS this way
 			if c.TLS.LetsEncryptEmail == "off" {
 				c.TLS.Enabled = false
+				return nil, nil
 			}
 		case 2:
 			certificateFile = args[0]
@@ -120,78 +121,8 @@ func Setup(c *setup.Controller) (middleware.Middleware, error) {
 		}
 
 		// load a directory of certificates, if specified
-		// modeled after haproxy: https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.1-crt
 		if loadDir != "" {
-			err := filepath.Walk(loadDir, func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					log.Printf("[WARNING] Unable to traverse into %s; skipping", path)
-					return nil
-				}
-				if info.IsDir() {
-					return nil
-				}
-				if strings.HasSuffix(strings.ToLower(info.Name()), ".pem") {
-					certBuilder, keyBuilder := new(bytes.Buffer), new(bytes.Buffer)
-					var foundKey bool
-
-					bundle, err := ioutil.ReadFile(path)
-					if err != nil {
-						return err
-					}
-
-					for {
-						// Decode next block so we can see what type it is
-						var derBlock *pem.Block
-						derBlock, bundle = pem.Decode(bundle)
-						if derBlock == nil {
-							break
-						}
-
-						if derBlock.Type == "CERTIFICATE" {
-							// Re-encode certificate as PEM, appending to certificate chain
-							pem.Encode(certBuilder, derBlock)
-						} else if derBlock.Type == "EC PARAMETERS" {
-							// EC keys are composed of two blocks: parameters and key
-							// (parameter block should come first)
-							if !foundKey {
-								// Encode parameters
-								pem.Encode(keyBuilder, derBlock)
-
-								// Key must immediately follow
-								derBlock, bundle = pem.Decode(bundle)
-								if derBlock == nil || derBlock.Type != "EC PRIVATE KEY" {
-									return c.Errf("%s: expected elliptic private key to immediately follow EC parameters", path)
-								}
-								pem.Encode(keyBuilder, derBlock)
-								foundKey = true
-							}
-						} else if derBlock.Type == "PRIVATE KEY" || strings.HasSuffix(derBlock.Type, " PRIVATE KEY") {
-							// RSA key
-							if !foundKey {
-								pem.Encode(keyBuilder, derBlock)
-								foundKey = true
-							}
-						} else {
-							return c.Errf("%s: unrecognized PEM block type: %s", path, derBlock.Type)
-						}
-					}
-
-					certPEMBytes, keyPEMBytes := certBuilder.Bytes(), keyBuilder.Bytes()
-					if len(certPEMBytes) == 0 {
-						return c.Errf("%s: failed to parse PEM data", path)
-					}
-					if len(keyPEMBytes) == 0 {
-						return c.Errf("%s: no private key block found", path)
-					}
-
-					err = cacheUnmanagedCertificatePEMBytes(certPEMBytes, keyPEMBytes)
-					if err != nil {
-						return c.Errf("%s: failed to load cert and key for %s: %v", path, c.Host, err)
-					}
-					log.Printf("[INFO] Successfully loaded TLS assets from %s", path)
-				}
-				return nil
-			})
+			err := loadCertsInDir(c, loadDir)
 			if err != nil {
 				return nil, err
 			}
@@ -201,6 +132,86 @@ func Setup(c *setup.Controller) (middleware.Middleware, error) {
 	setDefaultTLSParams(c.Config)
 
 	return nil, nil
+}
+
+// loadCertsInDir loads all the certificates/keys in dir, as long as
+// the file ends with .pem. This method of loading certificates is
+// modeled after haproxy, which expects the certificate and key to
+// be bundled into the same file:
+// https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.1-crt
+//
+// This function may write to the log as it walks the directory tree.
+func loadCertsInDir(c *setup.Controller, dir string) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Printf("[WARNING] Unable to traverse into %s; skipping", path)
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(strings.ToLower(info.Name()), ".pem") {
+			certBuilder, keyBuilder := new(bytes.Buffer), new(bytes.Buffer)
+			var foundKey bool // use only the first key in the file
+
+			bundle, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			for {
+				// Decode next block so we can see what type it is
+				var derBlock *pem.Block
+				derBlock, bundle = pem.Decode(bundle)
+				if derBlock == nil {
+					break
+				}
+
+				if derBlock.Type == "CERTIFICATE" {
+					// Re-encode certificate as PEM, appending to certificate chain
+					pem.Encode(certBuilder, derBlock)
+				} else if derBlock.Type == "EC PARAMETERS" {
+					// EC keys generated from openssl can be composed of two blocks:
+					// parameters and key (parameter block should come first)
+					if !foundKey {
+						// Encode parameters
+						pem.Encode(keyBuilder, derBlock)
+
+						// Key must immediately follow
+						derBlock, bundle = pem.Decode(bundle)
+						if derBlock == nil || derBlock.Type != "EC PRIVATE KEY" {
+							return c.Errf("%s: expected elliptic private key to immediately follow EC parameters", path)
+						}
+						pem.Encode(keyBuilder, derBlock)
+						foundKey = true
+					}
+				} else if derBlock.Type == "PRIVATE KEY" || strings.HasSuffix(derBlock.Type, " PRIVATE KEY") {
+					// RSA key
+					if !foundKey {
+						pem.Encode(keyBuilder, derBlock)
+						foundKey = true
+					}
+				} else {
+					return c.Errf("%s: unrecognized PEM block type: %s", path, derBlock.Type)
+				}
+			}
+
+			certPEMBytes, keyPEMBytes := certBuilder.Bytes(), keyBuilder.Bytes()
+			if len(certPEMBytes) == 0 {
+				return c.Errf("%s: failed to parse PEM data", path)
+			}
+			if len(keyPEMBytes) == 0 {
+				return c.Errf("%s: no private key block found", path)
+			}
+
+			err = cacheUnmanagedCertificatePEMBytes(certPEMBytes, keyPEMBytes)
+			if err != nil {
+				return c.Errf("%s: failed to load cert and key for %s: %v", path, c.Host, err)
+			}
+			log.Printf("[INFO] Successfully loaded TLS assets from %s", path)
+		}
+		return nil
+	})
 }
 
 // setDefaultTLSParams sets the default TLS cipher suites, protocol versions,
@@ -231,7 +242,7 @@ func setDefaultTLSParams(c *server.Config) {
 
 	// Default TLS port is 443; only use if port is not manually specified,
 	// TLS is enabled, and the host is not localhost
-	if c.Port == "" && c.TLS.Enabled && !c.TLS.Manual && c.Host != "localhost" {
+	if c.Port == "" && c.TLS.Enabled && (!c.TLS.Manual || c.TLS.OnDemand) && c.Host != "localhost" {
 		c.Port = "443"
 	}
 }

--- a/server/config.go
+++ b/server/config.go
@@ -68,7 +68,7 @@ type TLSConfig struct {
 	Enabled                  bool // will be set to true if TLS is enabled
 	LetsEncryptEmail         string
 	Manual                   bool // will be set to true if user provides own certs and keys
-	Managed                  bool // will be set to true if config qualifies for automatic/managed HTTPS
+	Managed                  bool // will be set to true if config qualifies for implicit automatic/managed HTTPS
 	OnDemand                 bool // will be set to true if user enables on-demand TLS (obtain certs during handshakes)
 	Ciphers                  []uint16
 	ProtocolMinVersion       uint16

--- a/server/server.go
+++ b/server/server.go
@@ -63,15 +63,7 @@ func New(addr string, configs []Config, gracefulTimeout time.Duration) (*Server,
 	var useTLS, useOnDemandTLS bool
 	if len(configs) > 0 {
 		useTLS = configs[0].TLS.Enabled
-		if useTLS {
-			host, _, err := net.SplitHostPort(addr)
-			if err != nil {
-				host = addr
-			}
-			if host == "" && configs[0].TLS.OnDemand {
-				useOnDemandTLS = true
-			}
-		}
+		useOnDemandTLS = configs[0].TLS.OnDemand
 	}
 
 	s := &Server{


### PR DESCRIPTION
Now attempt to staple OCSP even for certs that don't have an existing staple (issue #605). "tls off" short-circuits tls setup function. Now we call getEmail() when setting up an acme.Client that does renewals, rather than making a new account with empty email address. Check certificate expiry every 12 hours, and OCSP every hour.